### PR TITLE
feat: Implement basic metrics and recommendations endpoints

### DIFF
--- a/dashboard/static/script.js
+++ b/dashboard/static/script.js
@@ -2,7 +2,21 @@ document.addEventListener("DOMContentLoaded", () => {
     fetch("/api/metrics")
         .then(response => response.json())
         .then(data => {
-            document.getElementById("metrics").innerText = JSON.stringify(data);
+            const metricsDiv = document.getElementById("metrics");
+            metricsDiv.innerHTML = ""; // Clear previous content
+            data.metrics.forEach(metric => {
+                const metricEntry = document.createElement("div");
+                metricEntry.innerHTML = `
+                    <p>Endpoint: ${metric.endpoint}</p>
+                    <p>Response Time: ${metric.response_time} ms</p>
+                    <p>Status Code: ${metric.status_code}</p>
+                    <p>Timestamp: ${metric.timestamp}</p>
+                    <p>CPU Usage: ${metric.cpu_usage}%</p>
+                    <p>Memory Usage: ${metric.memory_usage} MB</p>
+                    <hr>
+                `;
+                metricsDiv.appendChild(metricEntry);
+            });
         })
         .catch(error => console.error("Error fetching metrics:", error));
 });


### PR DESCRIPTION
- Added functionality to collect and retrieve metrics through /api/metrics endpoints.
- Implemented a basic recommendation engine at /api/recommendations.
- Created a /api/mock-metrics endpoint for generating mock data.
- Updated the root endpoint to display an overview of available API routes.